### PR TITLE
Fixes IE bug: Invalid attempt to spread non-iterable instance

### DIFF
--- a/src/dataframe.js
+++ b/src/dataframe.js
@@ -342,7 +342,7 @@ class DataFrame {
         const gdfToJoin = dfToJoin.groupBy(...columns);
         return [
             this.__newInstance__([], newColumns),
-            ...iter(
+            ...Array.from(iter(
                 [
                     ...(types[0]
                         ? this._joinByType(gdf, gdfToJoin, types[0], newColumns)
@@ -352,7 +352,7 @@ class DataFrame {
                         : [])
                 ],
                 group => group.restructure(newColumns)
-            )
+            ))
         ]
             .reduce((p, n) => p.union(n))
             .dropDuplicates();
@@ -538,14 +538,14 @@ class DataFrame {
         const toShow = [
             header,
             Array(header.length).join("-"),
-            ...iter(
+            ...Array.from(iter(
                 this[__rows__],
                 row => {
                     token++;
                     return makeRow(row.toArray());
                 },
                 () => token >= rows
-            )
+            ))
         ].join("\n");
         if (!quiet) {
             console.log(toShow);
@@ -847,7 +847,7 @@ class DataFrame {
                           .reduce((p, n) => p && n)
                 : condition;
         const filteredRows = [
-            ...iter(this[__rows__], (row, i) => (func(row, i) ? row : false))
+            ...Array.from(iter(this[__rows__], (row, i) => (func(row, i) ? row : false)))
         ];
         return this.__newInstance__(filteredRows, this[__columns__]);
     }
@@ -886,7 +886,7 @@ class DataFrame {
      */
     map(func) {
         return this.__newInstance__(
-            [...iter(this[__rows__], (row, i) => func(row, i))],
+            [...Array.from(iter(this[__rows__], (row, i) => func(row, i)))],
             this[__columns__]
         );
     }
@@ -1004,14 +1004,14 @@ class DataFrame {
         let token = 0;
         return this.__newInstance__(
             [
-                ...iter(
+                ...Array.from(iter(
                     this.shuffle()[__rows__],
                     row => {
                         token++;
                         return row;
                     },
                     () => token >= nRows
-                )
+                ))
             ],
             this[__columns__]
         );
@@ -1031,13 +1031,13 @@ class DataFrame {
         return [
             this.__newInstance__(
                 [
-                    ...iter(this.shuffle()[__rows__], row => {
+                    ...Array.from(iter(this.shuffle()[__rows__], row => {
                         if (token < nRows) {
                             token++;
                             return row;
                         }
                         restRows.push(row);
-                    })
+                    }))
                 ],
                 this[__columns__]
             ),


### PR DESCRIPTION
Creating an array from an generator prior to using the spread operator
avoids the TyperError.

Reference: Issue #79