### PR TITLE
fix sorting missing values position

### DIFF
--- a/src/dataframe.js
+++ b/src/dataframe.js
@@ -1006,9 +1006,12 @@ class DataFrame {
             return _columnNames
                 .map((col) => {
                     const [pValue, nValue] = [p.get(col), n.get(col)];
-                    if (_checkMissingValue(pValue)) {
+                    const [pMissing, nMissing] = [_checkMissingValue(pValue),_checkMissingValue(nValue)];
+                    if (pMissing && nMissing) {
+                        return 0;
+                    } else if (pMissing) {
                         return _missingValuesPosition === "last" ? 1 : -1;
-                    } else if (_checkMissingValue(nValue)) {
+                    } else if (nMissing) {
                         return _missingValuesPosition === "last" ? -1 : 1;
                     } else if (typeof pValue !== typeof nValue) {
                         throw new MixedTypeError([

--- a/tests/sort.test.js
+++ b/tests/sort.test.js
@@ -1,0 +1,31 @@
+import test from "ava";
+
+import DataFrame from "../src/dataframe";
+
+test("Sort multiple cols with undefined ", assert => {
+    const df = new DataFrame(
+        [
+            { col1: 1, col2: "A", },
+            { col1: 2, col2: undefined },
+            { col1: 3, col2: "B" },
+            { col1: undefined, col2: "On the road" },
+            { col1: undefined, col2: undefined },
+            { col1: undefined, col2: "C" }
+        ]
+    );
+
+    const sorted = df.sortBy(['col1', 'col2'], false, 'last');
+
+    assert.deepEqual(
+        sorted.toCollection(),
+        [
+            { col1: 1, col2: 'A' },
+            { col1: 3, col2: 'B' },
+            { col1: 2, col2: undefined },
+            { col1: undefined, col2: 'C' },
+            { col1: undefined, col2: 'On the road' },
+            { col1: undefined, col2: undefined },
+          ],
+        "sort multiple undef cols"
+    );
+});


### PR DESCRIPTION
Hi,

The current sorting order was broken in case we have multiple columns to compare that contain empty values.

Attached a simple fix and a test case that illustrates this.